### PR TITLE
Remove description to prevent error

### DIFF
--- a/server.py
+++ b/server.py
@@ -10,7 +10,6 @@ from features import common, entities, apm, synthetics, alerts
 # unless run directly with `python server.py` (not recommended for this setup).
 mcp = FastMCP(
     "New Relic NerdGraph MCP Server",
-    description="Provides tools and resources to interact with the New Relic NerdGraph API via MCP.",
     dependencies=["requests"] # Core dependency needed by client.py
 )
 


### PR DESCRIPTION
```javascript
[08/13/25 17:53:52] ERROR    Failed to run: FastMCP.__init__() got an unexpected keyword argument 'description'         cli.py:428
```
